### PR TITLE
fix install requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-pdfminer.six
 pandas
 pytest
 gitpython
-# Keep this until next PyCap release, then switch to PyPi
-pycap @ git+git://github.com/redcap-tools/PyCap#egg=PyCap
+pycap>=1.1.3
+
 


### PR DESCRIPTION
With the new release of pycap we can switch to installation from pypi instead of github