### PR TITLE
Add multiple download experiment on the CLI

### DIFF
--- a/elab_bridge/cli.py
+++ b/elab_bridge/cli.py
@@ -2,7 +2,7 @@
 Provide CLI for the main functionalities of the elab bridge
 """
 
-from elab_bridge.server_interface import download_experiment
+from elab_bridge.server_interface import download_experiment, extended_download
 
 
 def main(command_line=None):
@@ -29,6 +29,14 @@ def main(command_line=None):
     download.add_argument("-c", "--compressed", action='store_true',
                           help="Compress the output file (use labels and merge checkbox columns)")
 
+    extended_download_parser = subparsers.add_parser('extended_download', help='Download experiments with extended options')
+    extended_download_parser.add_argument("destination", nargs=1, metavar='destination', type=str,
+                                          help="The destination directory to save the downloaded experiments.")
+    extended_download_parser.add_argument("config_json", nargs=1, metavar='config_json', type=str,
+                                          help="The json configuration file of the project")
+    extended_download_parser.add_argument("tags", nargs='+', metavar='tags', type=str,
+                                          help="List of tags of the experiments to download")
+
     # parse arguments
     args = parser.parse_args(command_line)
 
@@ -44,6 +52,9 @@ def main(command_line=None):
 
         download_experiment(args.destination[0], args.config_json[0], format=args.format[0],
                          compressed=bool(args.compressed))
+
+    elif args.command == 'extended_download':
+        extended_download(args.destination[0], args.config_json[0], args.tags)
 
 
 if __name__ == '__main__':

--- a/elab_bridge/tests/test_cli.py
+++ b/elab_bridge/tests/test_cli.py
@@ -50,3 +50,19 @@ def test_download(initialize_test_dir):
     #                         stdout=subprocess.PIPE)
     # assert 'error' not in str(result.stdout)
     # assert pathlib.Path(output_file).exists()
+
+def test_download(initialize_test_dir):
+    """
+    Check extended_download
+    """
+
+    tags = ['BIDS']
+    output_file = test_directory / 'cli_download_test.csv'
+
+    result = subprocess.run(['ElabBridge', 'extended_download', output_file, SERVER_CONFIG_YAML] + tags,
+                             stdout=subprocess.PIPE)
+
+    assert 'error' not in str(result.stdout)
+    assert output_file.exists()
+    output_file.unlink()
+


### PR DESCRIPTION
Useful implementation allowing users to export multiple experiences. This fits in with the pipeline, enabling standardization of metadata.